### PR TITLE
Fix event type in input handler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, useState } from "react";
-import words from "./words.js";
+import React, { FormEvent, useState } from "react";
+import words from "./words";
 import "./App.css";
 
 const dictionary = new Set(words);
@@ -75,9 +75,9 @@ function getAllValidWords(letters) {
 
 function App() {
   const [inputValue, setInputValue] = useState("");
-  const [words, setWords] = useState([]);
+  const [words, setWords] = useState<string[]>([]);
 
-  const handleChange = (event: Event) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value);
   };
 
@@ -90,7 +90,7 @@ function App() {
   return (
     <>
       <form onSubmit={handleSubmit}>
-        <input value={"" || inputValue} onChange={handleChange}></input>
+        <input value={inputValue} onChange={handleChange}></input>
         <button>submit</button>
         {words.map((word) => (
           <p id={word}>{word}</p>


### PR DESCRIPTION
## Summary
- fix incorrect event type in `App.tsx`
- rename `src/words.js` to `src/words.ts`
- type the words state array

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880cd8b597883249eb17fe46216222a