### PR TITLE
Fix React list item key

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,7 +93,7 @@ function App() {
         <input value={inputValue} onChange={handleChange}></input>
         <button>submit</button>
         {words.map((word) => (
-          <p id={word}>{word}</p>
+          <p key={word}>{word}</p>
         ))}
       </form>
     </>


### PR DESCRIPTION
## Summary
- fix React list rendering to use a `key` prop instead of misusing `id`

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm run build` *(fails: TS errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_688435c61e4883249df6598b3c41f4ee