### PR TITLE
Add vitest and basic solver tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -23,6 +24,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "typescript": "^5.4.2",
-    "vite": "^5.1.6"
+    "vite": "^5.1.6",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/__tests__/solver.test.ts
+++ b/src/__tests__/solver.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { getAllValidWords } from '../solver'
+
+const dictionary = new Set(['abcd', 'abdc', 'badc', 'cabd', 'zzzz', 'aaaa'])
+
+describe('getAllValidWords', () => {
+  it('returns words containing the center letter only', () => {
+    const letters = 'abcd'
+    const result = getAllValidWords(letters, dictionary).sort()
+    expect(result).toEqual(['abcd', 'abdc', 'badc', 'cabd'].sort())
+  })
+
+  it('ignores words not using only provided letters', () => {
+    const letters = 'abcde'
+    const dict = new Set(['abee', 'abce', 'aeee', 'abef'])
+    const result = getAllValidWords(letters, dict).sort()
+    expect(result).toEqual(['abee', 'abce', 'aeee'].sort())
+  })
+})

--- a/src/solver.ts
+++ b/src/solver.ts
@@ -1,0 +1,61 @@
+export function getAllCombinationsWithRepetition(str: string, maxLength: number): string[] {
+  const results: string[] = [];
+
+  function helper(prefix: string, remainingLength: number) {
+    if (remainingLength === 0) {
+      return;
+    }
+    for (let i = 0; i < str.length; i++) {
+      const newPrefix = prefix + str[i];
+      results.push(newPrefix);
+      helper(newPrefix, remainingLength - 1);
+    }
+  }
+
+  for (let length = 1; length <= maxLength; length++) {
+    helper("", length);
+  }
+
+  return results;
+}
+
+export function getPermutations(str: string): string[] {
+  if (str.length <= 1) {
+    return [str];
+  }
+  const permutations: string[] = [];
+  const smallerPerms = getPermutations(str.slice(1));
+  const firstChar = str[0];
+  for (const perm of smallerPerms) {
+    for (let i = 0; i <= perm.length; i++) {
+      const newPerm = perm.slice(0, i) + firstChar + perm.slice(i);
+      permutations.push(newPerm);
+    }
+  }
+  return permutations;
+}
+
+export function getAllPermutationsOfCombinationsWithRepetition(str: string, maxLength: number): string[] {
+  const combinations = getAllCombinationsWithRepetition(str, maxLength);
+  const allPermutations = new Set<string>();
+  for (const combination of combinations) {
+    const permutations = getPermutations(combination);
+    permutations.forEach((perm) => allPermutations.add(perm));
+  }
+  return Array.from(allPermutations);
+}
+
+export function filterValidWords(permutations: string[], letters: string, dictionary: Set<string>): string[] {
+  return permutations.filter(
+    (word) =>
+      word.length >= 4 &&
+      word.includes(letters[letters.length - 1]) &&
+      dictionary.has(word),
+  );
+}
+
+export function getAllValidWords(letters: string, dictionary: Set<string>): string[] {
+  const permutations = getAllPermutationsOfCombinationsWithRepetition(letters, 4);
+  const validWords = filterValidWords(permutations, letters, dictionary);
+  return Array.from(new Set(validWords));
+}


### PR DESCRIPTION
## Summary
- add vitest and expose test script
- implement solver functions in `src/solver.ts`
- test getAllValidWords with small dictionaries

## Testing
- `npm test -- -t getAllValidWords`

------
https://chatgpt.com/codex/tasks/task_e_688435c428648324ab412cf7429f163e